### PR TITLE
setDoPar() and setDoSeq() return previously registered settings.

### DIFF
--- a/R/getDoPar.R
+++ b/R/getDoPar.R
@@ -87,16 +87,22 @@ getDoParVersion <- function() {
 }
 
 # used internally to get the currently registered parallel backend
-getDoPar <- function() {
+getDoPar <- function(warn = TRUE) {
   if (exists('fun', where=.foreachGlobals, inherits=FALSE)) {
-    list(fun=.foreachGlobals$fun, data=.foreachGlobals$data)
+    structure(list(
+      fun=.foreachGlobals$fun,
+      data=.foreachGlobals$data,
+      info=.foreachGlobals$info
+    ), class="DoPar")
   } else {
-    if (!exists('parWarningIssued', where=.foreachGlobals, inherits=FALSE)) {
-      warning('executing %dopar% sequentially: no parallel backend registered',
-              call.=FALSE)
-      assign('parWarningIssued', TRUE, pos=.foreachGlobals, inherits=FALSE)
+    if (warn) {
+      if (!exists('parWarningIssued', where=.foreachGlobals, inherits=FALSE)) {
+        warning('executing %dopar% sequentially: no parallel backend registered',
+                call.=FALSE)
+        assign('parWarningIssued', TRUE, pos=.foreachGlobals, inherits=FALSE)
+      }
     }
-    list(fun=doSEQ, data=NULL)
+    structure(list(fun=doSEQ, data=NULL, info=NULL), class=c("DoPar", "DoSeq"))
   }
 }
 

--- a/R/getDoSeq.R
+++ b/R/getDoSeq.R
@@ -88,9 +88,13 @@ getDoSeqVersion <- function() {
 # used internally to get the currently registered parallel backend
 getDoSeq <- function() {
   if (exists('seqFun', where=.foreachGlobals, inherits=FALSE)) {
-    list(fun=.foreachGlobals$seqFun, data=.foreachGlobals$seqdata)
+    structure(list(
+      fun=.foreachGlobals$seqFun,
+      data=.foreachGlobals$seqData,
+      info=.foreachGlobals$seqInfo
+    ), class="DoSeq")
   } else {
-    list(fun=doSEQ, data=NULL)
+    structure(list(fun=doSEQ, data=NULL, info=NULL), class=c("DoPar", "DoSeq"))
   }
 }
 

--- a/R/setDoPar.R
+++ b/R/setDoPar.R
@@ -24,11 +24,21 @@
 #' @param fun A function that implements the functionality of `%dopar%`.
 #' @param data Data to be passed to the registered function.
 #' @param info Function that retrieves information about the backend.
+#' @return (invisible) The previously registered `DoPar` settings.
 #' @seealso
 #' [`%dopar%`]
 #' @keywords utilities
 #' @export
 setDoPar <- function(fun, data=NULL, info=function(data, item) NULL) {
+  if (inherits(fun, "DoPar")) {
+    dopar <- fun
+    fun  <- dopar$fun
+    info <- dopar$info
+    data <- dopar$data
+  }
+
+  dopar <- getDoPar(warn=FALSE)
+  
   tryCatch(
     {
       assign('fun', fun, pos=.foreachGlobals, inherits=FALSE)
@@ -43,5 +53,7 @@ setDoPar <- function(fun, data=NULL, info=function(data, item) NULL) {
     remove('info', envir=.foreachGlobals)
          e
   })
+
+  invisible(dopar)
 }
 

--- a/R/setDoSeq.R
+++ b/R/setDoSeq.R
@@ -24,11 +24,21 @@
 #' @param fun A function that implements the functionality of `%dopar%`.
 #' @param data Data to be passed to the registered function.
 #' @param info Function that retrieves information about the backend.
+#' @return (invisible) The previously registered `DoSeq` settings.
 #' @seealso
-#' [`%dopar%`]
+#' [`%do%`]
 #' @keywords utilities
 #' @export
 setDoSeq <- function(fun, data=NULL, info=function(data, item) NULL) {
+  if (inherits(fun, "DoSeq")) {
+    doseq <- fun
+    fun  <- doseq$fun
+    info <- doseq$info
+    data <- doseq$data
+  }
+
+  doseq <- getDoSeq()
+  
   tryCatch(
     {
        assign('seqFun', fun, pos=.foreachGlobals, inherits=FALSE)
@@ -43,5 +53,7 @@ setDoSeq <- function(fun, data=NULL, info=function(data, item) NULL) {
   remove('info', envir = .foreachGlobals)
          e
   })
+
+  invisible(doseq)
 }
 

--- a/man/setDoPar.Rd
+++ b/man/setDoPar.Rd
@@ -13,6 +13,9 @@ setDoPar(fun, data = NULL, info = function(data, item) NULL)
 
 \item{info}{Function that retrieves information about the backend.}
 }
+\value{
+(invisible) The previously registered \code{DoPar} settings.
+}
 \description{
 The \code{setDoPar} function is used to register a parallel backend with the
 foreach package.  This isn't normally executed by the user.  Instead, packages

--- a/man/setDoSeq.Rd
+++ b/man/setDoSeq.Rd
@@ -13,6 +13,9 @@ setDoSeq(fun, data = NULL, info = function(data, item) NULL)
 
 \item{info}{Function that retrieves information about the backend.}
 }
+\value{
+(invisible) The previously registered \code{DoSeq} settings.
+}
 \description{
 The \code{setDoSeq} function is used to register a sequential backend with the
 foreach package.  This isn't normally executed by the user.  Instead, packages


### PR DESCRIPTION
setDoPar() and setDoSeq() return previously registered settings.
Previously registered settings can be reset by passing them to setDoPar() and setDoSeq(), respectively.

Fixes #19